### PR TITLE
Change text to span for text on header

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import './Header.css';
 
 function HeaderText() {
-    return <text id="header-text">LOREM</text>
+    return <span id="header-text">LOREM</span>
 }
 
 function Header() {


### PR DESCRIPTION
There was a warning saying browser can't recognize text element. Changed text to span.

Resolves: #8