### PR TITLE
Change text to span for text on footer

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -4,7 +4,7 @@ import './Footer.css';
 function Footer() {
         return (
             <footer id="footer">
-                <text id="footer-text">LOREM IPSUM ©2021</text>
+                <span id="footer-text">LOREM IPSUM ©2021</span>
             </footer>
         )
 }


### PR DESCRIPTION
There was a warning saying browser can't recognize text element. Changed text to span.

Resolves: #12