### PR TITLE
Fix scaling footer text on mobile version

### DIFF
--- a/src/components/Footer.css
+++ b/src/components/Footer.css
@@ -31,8 +31,8 @@
 
     #footer-text {
         bottom: 15px;
-        left: calc(126/412 * 100%);
-        width: calc(143/412 * 100%);
+        left: calc(126/269 * (100vw - 143px));
+        width: 143px;
         font-size: 14px;
     } 
 }


### PR DESCRIPTION
Footer text was wrapping on mobile version.
Fix was to scale left margin with view width.

Resolves: #14